### PR TITLE
Netbox: Make username and password config optional

### DIFF
--- a/netbox/config.json
+++ b/netbox/config.json
@@ -18,8 +18,8 @@
     "keyfile": "privatekey.pem"
   },
   "schema": {
-    "user": "str",
-    "password": "str",
+    "user": "str?",
+    "password": "str?",
     "https": "bool",
     "certfile": "str",
     "keyfile": "str"


### PR DESCRIPTION
I'm unable to ever re-start this add-on currently. I believe this is the fix, but I'm also surprised to be the first person to hit such a major issue. Please let me know if there's something I'm missing here.